### PR TITLE
Task/fit on whole test set

### DIFF
--- a/python-lib/dku_error_analysis_mpp/dku_error_analyzer.py
+++ b/python-lib/dku_error_analysis_mpp/dku_error_analyzer.py
@@ -35,7 +35,7 @@ class DkuErrorAnalyzer(ErrorAnalyzer):
         self._model_predictor = model_handler.get_predictor()
         self._max_num_rows = max_num_rows
 
-        probability_threshold = model_handler.get_predictor().params.model_perf.get('usedThreshold', None)
+        probability_threshold = self._model_predictor.params.model_perf.get('usedThreshold', None)
         feature_names = self._model_predictor.get_features()
         super(DkuErrorAnalyzer, self).__init__(model_handler.get_clf(), feature_names, param_grid, probability_threshold, random_state)
 


### PR DESCRIPTION
* We no longer split the original test set, the ErrorTree is fit on the whole set.
* We retrieve the threshold used by doctor to use it when scoring with primary model

This is in relation with [this PR on mealy](https://github.com/dataiku/mealy/pull/22)