### PR TITLE
Fixes on tree parser

### DIFF
--- a/python-lib/dku_error_analysis_tree_parsing/tree_parser.py
+++ b/python-lib/dku_error_analysis_tree_parsing/tree_parser.py
@@ -94,30 +94,20 @@ class TreeParser(object):
             self.preprocessed_feature_mapping[preprocessed_name] = self.SplitParameters(Node.TYPES.NUM, step.column_name, friendly_name=friendly_name)
 
     # NUMERICAL HANDLING
-    def _add_preprocessed_rescaled_num_feature(self, original_name):
-        original_idx = self.feature_list.index(original_name)
-        add_feature = lambda array, col: pd.Series(array[:, original_idx]).apply(lambda x: denormalize_feature_value(self.rescalers.get(original_name), x))
-        name = "preprocessed:rescaled:{}".format(original_name)
-        return add_feature, name
-
     def _add_identity_mapping(self, original_name):
         self.num_features.add(original_name)
-        add_feature, name = self._add_preprocessed_rescaled_num_feature(original_name)
-        self.preprocessed_feature_mapping[original_name] = self.SplitParameters(Node.TYPES.NUM,
-            original_name, add_preprocessed_feature=add_feature, friendly_name=name)
+        self.preprocessed_feature_mapping[original_name] = self.SplitParameters(Node.TYPES.NUM, original_name)
 
     def _add_binarize_mapping(self, step):
         self.num_features.add(step.in_col)
-        add_feature, name = self._add_preprocessed_rescaled_num_feature(step.in_col)
-        self.preprocessed_feature_mapping["num_binarized:" + step._output_name()] = self.SplitParameters(Node.TYPES.NUM, step.in_col, step.threshold, add_preprocessed_feature=add_feature, friendly_name=name)
+        self.preprocessed_feature_mapping["num_binarized:" + step._output_name()] = self.SplitParameters(Node.TYPES.NUM, step.in_col, step.threshold)
 
     def _add_quantize_mapping(self, step):
         bounds = step.r["bounds"]
         value_func = lambda threshold: float(bounds[int(threshold) + 1])
         preprocessed_name = "num_quantized:{0}:quantile:{1}".format(step.in_col, step.nb_bins)
-        add_feature, name = self._add_preprocessed_rescaled_num_feature(step.in_col)
         self.num_features.add(step.in_col)
-        self.preprocessed_feature_mapping[preprocessed_name] = self.SplitParameters(Node.TYPES.NUM, step.in_col, value_func=value_func, add_preprocessed_feature=add_feature, friendly_name=name)
+        self.preprocessed_feature_mapping[preprocessed_name] = self.SplitParameters(Node.TYPES.NUM, step.in_col, value_func=value_func)
 
     # VECTOR HANDLING
     def _add_unfold_mapping(self, step):

--- a/resource/js/treeVisualization.js
+++ b/resource/js/treeVisualization.js
@@ -66,7 +66,7 @@ app.service("TreeUtils", function(Format) {
                 middle += "one of ";
             }
             return {
-                left: displayableFeature(node.feature),
+                left: node.feature,
                 middle,
                 right: node.values.join(", ")
             }
@@ -74,7 +74,7 @@ app.service("TreeUtils", function(Format) {
         const sign = node.hasOwnProperty("end") ? "≤" : ">";
         const bound = node.hasOwnProperty("end") ? node.end : node.beginning;
         return {
-            left: displayableFeature(node.feature),
+            left: node.feature,
             middle: sign + Format.noBreakingSpace + Format.toFixedIfNeeded(bound, 5),
         }
     }
@@ -89,17 +89,11 @@ app.service("TreeUtils", function(Format) {
         return path;
     }
 
-    const displayableFeature = function(feature) {
-        const match = feature.match(/^preprocessed:rescaled:(.*)$/);
-        if (match) return match[1];
-        return feature;
-    }
     return {
         addNode,
         getDecisionRule,
         nodeValues,
         getPath,
-        displayableFeature,
         WRONG_PREDICTION
     }
 });
@@ -293,7 +287,7 @@ app.service("TreeInteractions", function(Format, TreeUtils) {
         .attr("text-anchor","middle")
         .attr("x", radius)
         .attr("y", radius*2 + 20)
-        .text(d => Format.ellipsis(TreeUtils.displayableFeature(treeData[d.children_ids[0].toString()].feature), 20));
+        .text(d => Format.ellipsis(treeData[d.children_ids[0].toString()].feature, 20));
 
         // Add new edges
         const edgeContainer = svg.selectAll(".edge").data(edgeData, d => d.target.node_id).enter().insert("g", "g");

--- a/resource/py/test_tree_parser.py
+++ b/resource/py/test_tree_parser.py
@@ -331,7 +331,7 @@ def test_impact(create_parser, mocker, preproc_array):
     a = parser.preprocessed_feature_mapping["impact:test:A"]
     assert a.node_type == Node.TYPES.NUM
     assert a.chart_name == "test"
-    assert a.feature == "test [enc_name on target]"
+    assert a.feature == "test [impact on target]"
     assert a.value is None
     assert not a.invert_left_and_right(0) and not a.invert_left_and_right(-.5)\
         and not a.invert_left_and_right(.5)
@@ -441,30 +441,8 @@ def test_unfold(create_parser, mocker, preproc_array):
 
 # NUM HANDLINGS
 @pytest.mark.numerical
-def test_add_preprocessed_rescaled_num(create_parser, mocker, preproc_array):
+def test_identity(create_parser, mocker, preproc_array):
     parser = create_parser()
-    parser.rescalers = {"test": "does_not_matter"}
-    mocker.patch("dku_error_analysis_tree_parsing.tree_parser.denormalize_feature_value",
-        side_effect=lambda x, y: x + " " + str(y))
-    func, name = parser._add_preprocessed_rescaled_num_feature("test")
-
-    assert (func(preproc_array, 32) == \
-        ["does_not_matter -1",
-        "does_not_matter 0",
-        "does_not_matter 0",
-        "does_not_matter 0",
-        "does_not_matter 1",
-        "does_not_matter 0",
-        "does_not_matter 4"]).all()
-    assert name == "preprocessed:rescaled:test"
-
-def mocked_add_preprocessed_rescaled_num_feature(original_name):
-    return "fake_function", "friendly_name"
-
-@pytest.mark.numerical
-def test_identity(create_parser, mocker):
-    parser = create_parser()
-    mocker.patch.object(parser, '_add_preprocessed_rescaled_num_feature', side_effect=mocked_add_preprocessed_rescaled_num_feature)
     parser._add_identity_mapping("test")
     assert len(parser.preprocessed_feature_mapping) == 1
     assert {"test"} == parser.num_features
@@ -472,53 +450,49 @@ def test_identity(create_parser, mocker):
     split = parser.preprocessed_feature_mapping["test"]
     assert split.node_type == Node.TYPES.NUM
     assert split.chart_name == "test"
-    assert split.feature == "friendly_name"
+    assert split.feature == "test"
     assert split.value is None
     assert split.value_func(.5) == .5 and split.value_func(-.5) == -.5
     assert not split.invert_left_and_right(0) and not split.invert_left_and_right(-.5)\
         and not split.invert_left_and_right(.5)
-    assert split.add_preprocessed_feature == "fake_function"
+    assert (split.add_preprocessed_feature(preproc_array, 0) == [-1,0,0,0,1,0,4]).all()
 
 @pytest.mark.numerical
-def test_binarize(create_parser, mocker):
+def test_binarize(create_parser, mocker, preproc_array):
     parser = create_parser()
-    patched = mocker.patch.object(parser, '_add_preprocessed_rescaled_num_feature', side_effect=mocked_add_preprocessed_rescaled_num_feature)
     step = mocker.Mock(in_col="test", threshold=42)
     step._output_name.return_value = "output"
     parser._add_binarize_mapping(step)
     assert len(parser.preprocessed_feature_mapping) == 1
-    assert patched.call_count == 1
     assert {"test"} == parser.num_features
 
     split = parser.preprocessed_feature_mapping["num_binarized:output"]
     assert split.node_type == Node.TYPES.NUM
     assert split.chart_name == "test"
-    assert split.feature == "friendly_name"
+    assert split.feature == "test"
     assert split.value == 42
     assert split.value_func(.5) == .5 and split.value_func(-.5) == -.5
     assert not split.invert_left_and_right(0) and not split.invert_left_and_right(-.5)\
         and not split.invert_left_and_right(.5)
-    assert split.add_preprocessed_feature == "fake_function"
+    assert (split.add_preprocessed_feature(preproc_array, 0) == [-1,0,0,0,1,0,4]).all()
 
 @pytest.mark.numerical
-def test_quantize(create_parser, mocker):
+def test_quantize(create_parser, mocker, preproc_array):
     parser = create_parser()
-    patched = mocker.patch.object(parser, '_add_preprocessed_rescaled_num_feature', side_effect=mocked_add_preprocessed_rescaled_num_feature)
     step = mocker.Mock(in_col="test", nb_bins=42, r={"bounds": ["0.5", "1.6", "7.8"]})
     parser._add_quantize_mapping(step)
     assert len(parser.preprocessed_feature_mapping) == 1
-    assert patched.call_count == 1
     assert {"test"} == parser.num_features
 
     split = parser.preprocessed_feature_mapping["num_quantized:test:quantile:42"]
     assert split.node_type == Node.TYPES.NUM
     assert split.chart_name == "test"
-    assert split.feature == "friendly_name"
+    assert split.feature == "test"
     assert split.value is None
     assert split.value_func(0) == 1.6 and split.value_func(1) == 7.8
     assert not split.invert_left_and_right(0) and not split.invert_left_and_right(-.5)\
         and not split.invert_left_and_right(.5)
-    assert split.add_preprocessed_feature == "fake_function"
+    assert (split.add_preprocessed_feature(preproc_array, 0) == [-1,0,0,0,1,0,4]).all()
 
 @pytest.mark.numerical
 def test_flag_missing(create_parser, mocker):


### PR DESCRIPTION
- Properly handle tf-idf preprocessed feature names
- Better friendly (UX) feature name for impact encoding with regression
- Remove unnecessary extra steps for depreprocessing (cf. what was done on DSS10 for v.1.1.0)

Corresponding unit tests have been updated as well