### PR TITLE
Bump python support up to 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.2.1 (2023-04-19)
+- Update code env description to support python versions 3.7, 3.8, 3.9, 3.10 and 3.11
+
 ## Version 1.2.0 (2023-04-19)
 - Webapp: Use contextual code env (i.e. the one used to train the model)
 - Webapp: Fix wrong handling of features generated from numerical quantile preprocessing (issue introduced in 1.1.3)

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Dataiku SAS
+   Copyright 2021-2023 Dataiku SAS
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Dataiku SAS
+   Copyright 2021 Dataiku SAS
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 - 2023 Dataiku SAS
+   Copyright 2023 Dataiku SAS
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Dataiku
+   Copyright 2021 - 2023 Dataiku SAS
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,8 +1,13 @@
 {
   "acceptedPythonInterpreters": [
-    "PYTHON36"
+    "PYTHON36",
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311"
   ],
-  "corePackagesSet": "PANDAS10",
+  "corePackagesSet": "AUTO",
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": true

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -3,8 +3,8 @@ matplotlib==3.3.4
 
 scikit-learn>=0.20,<1.1; python_version <= '3.10'
 scikit-learn==1.1.3; python_version >= '3.11'
-scipy>=1.2,<1.3; python_version <= '3.9'
-scipy==1.10.1; python_version >= '3.10'
+scipy>=1.2,<1.3; python_version <= '3.7'
+scipy==1.10.1; python_version >= '3.8'
 xgboost==0.82
 lightgbm>=3.2,<3.3
 statsmodels>=0.10,<0.11; python_version <= '3.9'

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -2,10 +2,12 @@ graphviz==0.16
 matplotlib==3.3.4
 
 scikit-learn>=0.20,<1.1
-scipy>=1.2,<1.3
+scipy>=1.2,<1.3; python_version <= '3.9'
+scipy==1.10.1; python_version >= '3.10'
 xgboost==0.82
 lightgbm>=3.2,<3.3
-statsmodels>=0.10,<0.11
+statsmodels>=0.10,<0.11; python_version <= '3.9'
+statsmodels==0.13.5; python_version >= '3.10'
 jinja2>=2.10,<2.11
 flask>=1.0,<1.1
 cloudpickle>=1.3,<1.6

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,7 +1,8 @@
 graphviz==0.16
 matplotlib==3.3.4
 
-scikit-learn>=0.20,<1.1
+scikit-learn>=0.20,<1.1; python_version <= '3.10'
+scikit-learn==1.1.3; python_version >= '3.11'
 scipy>=1.2,<1.3; python_version <= '3.9'
 scipy==1.10.1; python_version >= '3.10'
 xgboost==0.82

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "id" : "model-error-analysis",
-  "version" : "1.2.0",
+  "version" : "1.2.1",
   "meta" : {
     "label" : "Model Error Analysis",
     "description" : "Debug model performance with error analysis",

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "version" : "1.2.1",
   "meta" : {
     "label" : "Model Error Analysis",
-    "description" : "Debug model performance with error analysis",
+    "description" : "Debug model performance with error analysis. A code env is only required to use the example Jupyter Notebook.",
     "author" : "Dataiku (Agathe Guillemot, Du Phan, Simona Maggio)",
     "icon" : "icon-sitemap",
     "licenseInfo" : "Apache Software License",

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "version" : "1.2.1",
   "meta" : {
     "label" : "Model Error Analysis",
-    "description" : "Debug model performance with error analysis. A code env is only required to use the example Jupyter Notebook.",
+    "description" : "Debug model performance with error analysis. A code env is only required to use the Jupyter Notebook.",
     "author" : "Dataiku (Agathe Guillemot, Du Phan, Simona Maggio)",
     "icon" : "icon-sitemap",
     "licenseInfo" : "Apache Software License",

--- a/webapps/error-analysis/webapp.json
+++ b/webapps/error-analysis/webapp.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "label": "Model error analysis",
-    "description" : "Debug model performance with error analysis",
+    "description" : "Debug model performance with error analysis. This uses the code env that the analyzed model was originally trained with.",
     "icon": "icon-sitemap"
   },
   "baseType": "STANDARD",


### PR DESCRIPTION
This PR adds support for python 3.8, 3.9, 3.10 and 3.11, and bumps the plugin code env dependencies where necessary

Also, we update the plugin desc a bit 

[sc-132114]