### PR TITLE
Change numbering for previous version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 1.2.1 (2023-04-19)
+## Version 1.3.0 (2023-05-04)
 - Update code env description to support python versions 3.7, 3.8, 3.9, 3.10 and 3.11
 
 ## Version 1.2.0 (2023-04-19)

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "id" : "model-error-analysis",
-  "version" : "1.2.1",
+  "version" : "1.3.0",
   "meta" : {
     "label" : "Model Error Analysis",
     "description" : "Debug model performance with error analysis. A code env is only required to use the Jupyter Notebook.",


### PR DESCRIPTION
Bump for python versions should have been v1.3.0, instead of 1.2.1 - this fixes that