### PR TITLE
Release/12.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.3.1 (2023-11-01)
+- Fix method used in the notebook template
+
 ## Version 1.3.0 (2023-05-04)
 - Update code env description to support python versions 3.7, 3.8, 3.9, 3.10 and 3.11
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "id" : "model-error-analysis",
-  "version" : "1.3.0",
+  "version" : "1.3.1",
   "meta" : {
     "label" : "Model Error Analysis",
     "description" : "Debug model performance with error analysis. A code env is only required to use the Jupyter Notebook.",

--- a/python-lib/dku_error_analysis_model_parser/model_handler_utils.py
+++ b/python-lib/dku_error_analysis_model_parser/model_handler_utils.py
@@ -1,19 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from dku_error_analysis_utils import safe_str
 from dataiku.doctor.posttraining.model_information_handler import PredictionModelInformationHandler
-
 
 # Only used in the notebook template
 def get_model_handler(model, version_id=None):
-    try:
-        params = model.get_predictor(version_id).params
-        return PredictionModelInformationHandler(
-            params.split_desc, params.core_params, params.model_folder, params.model_folder
-        )
-    except Exception as e:
-        if "ordinal not in range(128)" in safe_str(e):
-            raise Exception("Model error analysis plugin only supports models built with Python 3. This one was built with Python 2.") from None
-        else:
-            raise e
+    fmi = "S-{project_key}-{model_id}-{version_id}".format(project_key=model.project_key, model_id=model.get_id(), version_id=version_id)
+    return PredictionModelInformationHandler.from_full_model_id(fmi)


### PR DESCRIPTION
[sc-157787]

## How to reproduce
- Train & deploy a classical model
- Create a notebook using MEA template, use the plugin codeenv for the kernel
<img width="905" alt="image" src="https://github.com/dataiku/dss-plugin-model-error-analysis/assets/22995764/a64710ed-8900-4c31-ba6a-75d9cf37f9a5">

- Launch it -> 💥  (at first call of `get_model_handler`)
  - Missing an arg in the `__init__` method of `PredictionModelInformationHandler` since folder context update