### PR TITLE
SKLearn-version specific access of feature names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.3.2 (2024-05-14)
+- Fix bug with TF-IDF column processing when used with sklearn > 1.0.0
+
 ## Version 1.3.1 (2023-11-01)
 - Fix method used in the notebook template
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "id" : "model-error-analysis",
-  "version" : "1.3.1",
+  "version" : "1.3.2",
   "meta" : {
     "label" : "Model Error Analysis",
     "description" : "Debug model performance with error analysis. A code env is only required to use the Jupyter Notebook.",

--- a/python-lib/dku_error_analysis_utils.py
+++ b/python-lib/dku_error_analysis_utils.py
@@ -10,3 +10,8 @@ def safe_str(val):
 class DkuMEAConstants(object):
     ERROR_COLUMN = "__dku_error__"
     MAX_NUM_ROWS = 100000
+
+
+def package_is_at_least(p, min_version):
+    from distutils.version import LooseVersion
+    return LooseVersion(p.__version__) >= LooseVersion(min_version)


### PR DESCRIPTION
[sc-183137]

Problem:

Model view kernel crashes for some models (logistic regression) when using sklearn >= 1.0

The issue is `get_feature_names()`, which appears to have been replaced with `get_feature_names_out()` - [source](https://stackoverflow.com/questions/70215049/attributeerror-tfidfvectorizer-object-has-no-attribute-get-feature-names-out)


Trace

```
[local] 2024-05-14 07:54:54,938 ERROR Traceback (most recent call last):
[local]   File "<string>", line 44, in load
[local]   File "/data/dataiku/dss_data/web_apps/MTPPROJECTMEA/C9El6Op/python-lib/dku_error_analysis_decision_tree/tree_handler.py", line 34, in train_tree
[local]     self.selected_feature_ids = set(range(min(len(self.tree.ranked_features), self.DEFAULT_MAX_NR_FEATURES)))
[local]   File "/data/dataiku/dss_data/web_apps/MTPPROJECTMEA/C9El6Op/python-lib/dku_error_analysis_decision_tree/tree_handler.py", line 24, in tree
[local]     return self.analyzer.tree
[local]   File "/data/dataiku/dss_data/web_apps/MTPPROJECTMEA/C9El6Op/python-lib/dku_error_analysis_mpp/dku_error_analyzer.py", line 51, in tree
[local]     self._parse_tree()
[local]   File "/data/dataiku/dss_data/web_apps/MTPPROJECTMEA/C9El6Op/python-lib/dku_error_analysis_mpp/dku_error_analyzer.py", line 61, in _parse_tree
[local]     tree_parser = TreeParser(self._model_handler, self.error_tree.estimator_,
[local]   File "/data/dataiku/dss_data/web_apps/MTPPROJECTMEA/C9El6Op/python-lib/dku_error_analysis_tree_parsing/tree_parser.py", line 52, in __init__
[local]     self._create_preprocessed_feature_mapping()
[local]   File "/data/dataiku/dss_data/web_apps/MTPPROJECTMEA/C9El6Op/python-lib/dku_error_analysis_tree_parsing/tree_parser.py", line 180, in _create_preprocessed_feature_mapping
[local]     {
[local]   File "/data/dataiku/dss_data/web_apps/MTPPROJECTMEA/C9El6Op/python-lib/dku_error_analysis_tree_parsing/tree_parser.py", line 171, in _add_tfidf_vect_mapping
[local]     for word, idf in zip(vec.get_feature_names(), vec.idf_):
[local] AttributeError: 'TfidfVectorizer' object has no attribute 'get_feature_names'
```

More info - https://stackoverflow.com/questions/70215049/attributeerror-tfidfvectorizer-object-has-no-attribute-get-feature-names-out